### PR TITLE
Swift 5.5 Support

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ fetchUserId().then { id in
 ```
 
 ```swift
-  let userId = try! await(fetchUserId())
+  let userId = try! awaitPromise(fetchUserId())
 ```
 
 Because async code is hard to write, hard to read, hard to reason about.   **A pain to maintain**
@@ -341,29 +341,29 @@ This is purely for the eyes :)
 
 ### Async/Await
 
-`await` waits for a promise to complete synchronously and yields the result :
+`awaitPromise` waits for a promise to complete synchronously and yields the result :
 
 ```swift
-let photos = try! await(getPhotos())
+let photos = try! awaitPromise(getPhotos())
 ```
 
 `async` takes a block and wraps it in a background Promise.
 
 ```swift
 async {
-  let photos = try await(getPhotos())
+  let photos = try awaitPromise(getPhotos())
 }
 ```
 Notice how we don't need the `!` anymore because `async` will catch the errors.
 
 
-Together, `async`/`await` enable us to write asynchronous code in a synchronous manner :
+Together, `async`/`awaitPromise` enable us to write asynchronous code in a synchronous manner :
 
 ```swift
 async {
-  let userId = try await(fetchUserId())
-  let userName = try await(fetchUserNameFromId(userId))
-  let isFollowed = try await(fetchUserFollowStatusFromName(userName))
+  let userId = try awaitPromise(fetchUserId())
+  let userName = try awaitPromise(fetchUserNameFromId(userId))
+  let isFollowed = try awaitPromise(fetchUserFollowStatusFromName(userName))
   return isFollowed
 }.then { isFollowed in
   print(isFollowed)
@@ -375,7 +375,7 @@ async {
 #### Await operators
 Await comes with `..` shorthand operator. The `..?` will fallback to a nil value instead of throwing.
 ```swift
-let userId = try await(fetchUserId())
+let userId = try awaitPromise(fetchUserId())
 ```
 Can be written like this:
 ```swift

--- a/Sources/Then/Await+Operators.swift
+++ b/Sources/Then/Await+Operators.swift
@@ -11,19 +11,19 @@ import Foundation
 prefix operator ..
 
 public prefix func .. <T>(promise: Promise<T>) throws -> T {
-    return try await(promise)
+    return try awaitPromise(promise)
 }
 
 public prefix func .. <T>(promise: Promise<T>?) throws -> T {
     guard let promise = promise else { throw PromiseError.unwrappingFailed }
-    return try await(promise)
+    return try awaitPromise(promise)
 }
 
 prefix operator ..?
 
 public prefix func ..? <T>(promise: Promise<T>) -> T? {
     do {
-        return try await(promise)
+        return try awaitPromise(promise)
     } catch {
         return nil
     }
@@ -32,7 +32,7 @@ public prefix func ..? <T>(promise: Promise<T>) -> T? {
 public prefix func ..? <T>(promise: Promise<T>?) -> T? {
     guard let promise = promise else { return nil }
     do {
-        return try await(promise)
+        return try awaitPromise(promise)
     } catch {
         return nil
     }

--- a/Sources/Then/Await.swift
+++ b/Sources/Then/Await.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Dispatch
 
-@discardableResult public func await<T>(_ promise: Promise<T>) throws -> T {
+@discardableResult public func awaitPromise<T>(_ promise: Promise<T>) throws -> T {
     var result: T!
     var error: Error?
     let group = DispatchGroup()

--- a/Sources/Then/Await.swift
+++ b/Sources/Then/Await.swift
@@ -9,6 +9,11 @@
 import Foundation
 import Dispatch
 
+@available(*, deprecated, message: "Use `awaitPromise<T>` instead, to avoid confusion & conflict with Swift standard library's `await`.")
+@discardableResult public func await<T>(_ promise: Promise<T>) throws -> T {
+    return try awaitPromise(promise)
+}
+
 @discardableResult public func awaitPromise<T>(_ promise: Promise<T>) throws -> T {
     var result: T!
     var error: Error?

--- a/Tests/ThenTests/AsyncAwaitTests.swift
+++ b/Tests/ThenTests/AsyncAwaitTests.swift
@@ -14,11 +14,11 @@ class AsyncAwaitTests: XCTestCase {
     func testAsyncAwaitChainWorks() {
         let exp = expectation(description: "")
         async {
-            let userId = try await(fetchUserId())
+            let userId = try awaitPromise(fetchUserId())
             XCTAssertEqual(userId, 1234)
-            let userName = try await(fetchUserNameFromId(userId))
+            let userName = try awaitPromise(fetchUserNameFromId(userId))
             XCTAssertEqual(userName, "John Smith")
-            let isFollowed = try await(fetchUserFollowStatusFromName(userName))
+            let isFollowed = try awaitPromise(fetchUserFollowStatusFromName(userName))
             XCTAssertFalse(isFollowed)
             exp.fulfill()
         }
@@ -28,7 +28,7 @@ class AsyncAwaitTests: XCTestCase {
     func testFailingAsyncAwait() {
         let exp = expectation(description: "")
         async {
-            _ = try await(failingFetchUserFollowStatusFromName("JohnDoe"))
+            _ = try awaitPromise(failingFetchUserFollowStatusFromName("JohnDoe"))
             XCTFail("testFailingAsyncAwait failed")
         }.onError { _ in
             exp.fulfill()
@@ -39,7 +39,7 @@ class AsyncAwaitTests: XCTestCase {
     func testCatchFailingAsyncAwait() {        
         let exp = expectation(description: "")
         do {
-            _ = try await(failingFetchUserFollowStatusFromName("JohnDoe"))
+            _ = try awaitPromise(failingFetchUserFollowStatusFromName("JohnDoe"))
             XCTFail("testCatchFailingAsyncAwait failed")
         } catch {
             exp.fulfill()
@@ -49,11 +49,11 @@ class AsyncAwaitTests: XCTestCase {
     
     func testAsyncAwaitUnwrapAtYourOwnRisk() {
         let exp = expectation(description: "")
-        let userId = try! await(fetchUserId())
+        let userId = try! awaitPromise(fetchUserId())
         XCTAssertEqual(userId, 1234)
-        let userName = try! await(fetchUserNameFromId(userId))
+        let userName = try! awaitPromise(fetchUserNameFromId(userId))
         XCTAssertEqual(userName, "John Smith")
-        let isFollowed = try! await(fetchUserFollowStatusFromName(userName))
+        let isFollowed = try! awaitPromise(fetchUserFollowStatusFromName(userName))
         XCTAssertFalse(isFollowed)
         exp.fulfill()
         waitForExpectations(timeout: 0.3, handler: nil)
@@ -62,7 +62,7 @@ class AsyncAwaitTests: XCTestCase {
     func testAsyncBlockCanReturnAValue() {
         let exp = expectation(description: "")
         async { () -> Int in
-            let userId = try await(fetchUserId())
+            let userId = try awaitPromise(fetchUserId())
             return userId
         }.then { userId in
             XCTAssertEqual(userId, 1234)


### PR DESCRIPTION
Background
In Swift 5.5, Swift team introduced Swift concurrency feature (https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html), which includes a new keyword await.
This will cause confusion and conflict with freshOS/Then 's global function await.

Users will get compiler errors if they build SoftwareCountry/Then with Swift 5.5. Although they still can use Then.await to avoid naming conflict, but it's not very convenient.

Changes
Rename await to awaitPromise.
Just FYI: Google's Promise also done this before: google/promises@5d07081
Add one await function (which will call awaitPromise actually) with deprecated mark for short term back-port supports.